### PR TITLE
Attribute dependency artifacts to requested top-level JLLS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JLLPrefixes"
 uuid = "afc68a34-7891-4c5a-9da1-1c62935e7b0d"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,10 +117,11 @@ const linux64_to_linux64 = Platform("x86_64", "linux"; target_arch="x86_64", tar
 
     # Test adding something that doesn't exist on a certain platform
     @testset "Platform Incompatibility" begin
-        @test_logs (:warn, r"Dependency Libuuid_jll does not have a mapping for artifact Libuuid for platform") (:warn, r"Unable to find installed artifact") begin
+        @test_logs (:warn, r"Dependency Libuuid_jll does not have a mapping for artifact Libuuid for platform") begin
             # This test _must_ be verbose, so we catch the appropriate logs
             artifact_paths = collect_artifact_paths(["Libuuid_jll"]; platform=Platform("x86_64", "macos"), verbose=true)
-            @test isempty(artifact_paths)
+            @test only(keys(artifact_paths)).name == "Libuuid_jll"
+            @test isempty(flatten_artifact_paths(artifact_paths))
         end
     end
 


### PR DESCRIPTION
Previously, we would return a simple `source JLL => artifacts` mapping as the output of `collect_artifact_paths()`, but this made it challenging to group together dependencies properly.  Instead, we now treat every JLL argument to `collect_artifact_paths()` as a top-level request, resolve them together, then return the set of all recursive dependencies of each top-level JLL in that dictionary.  This allows for easy determination of which artifacts are used by which top-level requests.  `flatten_artifact_paths()` now deduplicates its result.