### PR TITLE
Allow better overriding of `clones_dir`

### DIFF
--- a/src/JLLPrefixes.jl
+++ b/src/JLLPrefixes.jl
@@ -12,9 +12,19 @@ include("pkg_utils.jl")
 # Bring in helpers to deal with hardlinking, symlinking, etc...
 include("deployment.jl")
 
+global _git_clones_dir::Ref{String} = Ref{String}()
 function __init__()
     update_pkg_historical_stdlibs()
+
+    # Read in our `clones_dir` preference once
+    set_git_clones_dir!(@load_preference("clones_dir", @get_scratch!("git_clones")))
 end
+
+# provide programmatic way of setting it for this session
+function set_git_clones_dir!(clones_dir::String)
+    global _git_clones_dir[] = clones_dir
+end
+get_git_clones_dir() = _git_clones_dir[]
 
 """
     collect_artifact_metas(dependencies::Vector;

--- a/src/git_utils.jl
+++ b/src/git_utils.jl
@@ -10,7 +10,7 @@ then a cached git repository will not be updated if the commit already exists lo
 """
 function cached_git_clone(url::String;
                           desired_commit::Union{Nothing,String} = nothing,
-                          clones_dir::String = @load_preference("clone_dir", @get_scratch!("git_clones")),
+                          clones_dir::String = get_git_clones_dir(),
                           verbose::Bool = false)
     quiet_args = String[]
     if !verbose

--- a/src/git_utils.jl
+++ b/src/git_utils.jl
@@ -18,7 +18,7 @@ function cached_git_clone(url::String;
     end
 
     repo_path = joinpath(clones_dir, string(basename(url), "-", bytes2hex(sha256(url))))
-    if isdir(repo_path)
+    if isfile(joinpath(repo_path, "HEAD"))
         if verbose
             @info("Using cached git repository", url, repo_path)
         end
@@ -32,6 +32,9 @@ function cached_git_clone(url::String;
             run(git(["-C", repo_path, "fetch", quiet_args...]))
         end
     else
+        if isdir(repo_path)
+            rm(repo_path; recursive=true, force=true)
+        end
         if verbose
             @info("Cloning git repository", url, repo_path)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,17 @@
-using Test, JLLPrefixes, Base.BinaryPlatforms, Pkg
+using Test, JLLPrefixes, Base.BinaryPlatforms, Pkg, Preferences
 using JLLPrefixes: PkgSpec, flatten_artifact_paths
 
 const verbose = false
 const linux64 = Platform("x86_64", "linux")
 const linux64_to_linux64 = Platform("x86_64", "linux"; target_arch="x86_64", target_os="linux", target_libc="glibc")
+
+# On windows, we run into `$GIT_DIR too big` errors a lot if our git clones
+# are nested too deeply, as they default to, when using scratchspaces.
+# So here we just set them to be stored in a much shorter dirname:
+if Sys.iswindows()
+    JLLPrefixes.set_git_clones_dir!(mktempdir())
+end
+
 
 @testset "JLL collection" begin
     function check_zstd_jll(zstd_pkgspec, zstd_artifacts)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,3 +229,20 @@ end
     ]; platform=linux64_to_linux64, verbose)
     @test any(basename.(only([v for (k, v) in artifact_paths if k.name == "Binutils_jll"])) .== "cfacb1560e678d1d058d397d4b792f0d525ce5e1")
 end
+
+using JLLPrefixes: get_git_clones_dir, set_git_clones_dir!, cached_git_clone
+@testset "set_git_clones_dir!" begin
+    mktempdir() do clones_dir
+        old_clones_dir = get_git_clones_dir()
+        try
+            set_git_clones_dir!(clones_dir)
+            @test get_git_clones_dir() == clones_dir
+
+            path = cached_git_clone("https://github.com/JuliaBinaryWrappers/CompilerSupportLibraries_jll.jl")
+            @test startswith(path, clones_dir)
+        finally
+            set_git_clones_dir!(old_clones_dir)
+        end
+        @test get_git_clones_dir() == old_clones_dir
+    end
+end


### PR DESCRIPTION
Previously, we were looking up the preference `clones_dir` at the point of cloning down packages, but this is typically after we've activated a temporary environment, which means that it's actually quite hard for a user to set this value for our use.  :)