### PR TITLE
Don't mutate `platform` when adding `sanitize` flag

### DIFF
--- a/src/JLLPrefixes.jl
+++ b/src/JLLPrefixes.jl
@@ -56,6 +56,7 @@ function collect_artifact_metas(dependencies::Vector{PkgSpec};
 
     # Julia versions without https://github.com/JuliaLang/julia/pull/49502 need a workaround...
     if VERSION < v"1.10.0" && !haskey(platform, "sanitize")
+        platform = deepcopy(platform)
         platform["sanitize"] = "false"
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,9 @@ end
             artifact_paths = collect_artifact_paths(["Zstd_jll"]; platform, verbose)
             check_zstd_jll(first(artifact_paths)...)
 
+            # Ensure that `platform` is not mutated
+            @test !haskey(tags(platform), "sanitize")
+
             # Test that we're getting the kind of dynamic library we expect
             artifact_dir = first(first(values(artifact_paths)))
             if os(platform) == "windows"


### PR DESCRIPTION
It turns out that our workaround for Julia v1.9- to shoehorn in the `sanitize=false` tag actually mutated the caller's `platform` argument. Whoops, let's not do that.