### PR TITLE
Don't attempt to precompile JLL packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JLLPrefixes"
 uuid = "afc68a34-7891-4c5a-9da1-1c62935e7b0d"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/JLLPrefixes.jl
+++ b/src/JLLPrefixes.jl
@@ -66,7 +66,7 @@ function collect_artifact_metas(dependencies::Vector{PkgSpec};
     # We're going to create a project and install all dependent packages within
     # it, then create symlinks from those installed products to our build prefix
     deps_project = joinpath(project_dir, "Project.toml")
-    with_no_pkg_handrails() do; with_depot_path(pkg_depot) do; Pkg.activate(deps_project) do
+    with_no_pkg_handrails() do; with_no_auto_precompilation() do; with_depot_path(pkg_depot) do; Pkg.activate(deps_project) do
         pkg_io = verbose ? stdout : devnull
 
         # Update registry first, in case the jll packages we're looking for have just been registered/updated
@@ -225,7 +225,7 @@ function collect_artifact_metas(dependencies::Vector{PkgSpec};
             meta["dep_uuids"] = dep_dep_uuids
             artifact_metas[dep] = meta
         end
-    end; end; end
+    end; end; end; end
 
     return artifact_metas
 end

--- a/src/pkg_utils.jl
+++ b/src/pkg_utils.jl
@@ -40,6 +40,18 @@ else
     end
 end
 
+if isdefined(Pkg, :should_autoprecompile)
+    function with_no_auto_precompilation(f::Function)
+        withenv("JULIA_PKG_PRECOMPILE_AUTO" => "false") do
+            return f()
+        end
+    end
+else
+    function with_no_auto_precompilation(f::Function)
+        return f()
+    end
+end
+
 """
     collect_jll_uuids(manifest::Pkg.Types.Manifest, dependencies::Set{UUID})
 

--- a/src/pkg_utils.jl
+++ b/src/pkg_utils.jl
@@ -184,7 +184,7 @@ end
 
 function update_pkg_historical_stdlibs()
     # If we're using v1.x, we need to manually install these.
-    if pkgversion(HistoricalStdlibVersions) < v"2"
+    if !isdefined(HistoricalStdlibVersions, :register!)
         append!(empty!(Pkg.Types.STDLIBS_BY_VERSION), HistoricalStdlibVersions.STDLIBS_BY_VERSION)
         merge!(empty!(Pkg.Types.UNREGISTERED_STDLIBS), HistoricalStdlibVersions.UNREGISTERED_STDLIBS)
     end


### PR DESCRIPTION
Usually, when getting installed by `JLLPrefixes`, we don't actually care about the Julia bindings, we just care about the artifacts.

I wish there was a way to disable precompilation by passing arguments, or setting something in the `ctx`, rather than having to set an environment variable.