### PR TITLE
Ensure collecting already-installed deps doesn't modify Manifest.toml

### DIFF
--- a/src/pkg_utils.jl
+++ b/src/pkg_utils.jl
@@ -69,6 +69,7 @@ function collect_jll_uuids(manifest::Pkg.Types.Manifest, dependencies::Set{UUID}
             end
         end
     end
+    # Are we already converged?  If not, recurse with our new jlls list.
     if jlls == dependencies
         return jlls
     else


### PR DESCRIPTION
This ensures that we never call `Pkg.add()` if the JLL we're interested in already exists within the manifest.  If you place constraints on the JLL such that the already-installed version is incompatible, we update the manifest, but as long as it is satisfiable, the manifest should not be touched.